### PR TITLE
Bug fix: Over-sight in enabling update-route53

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,11 @@
     group: root
   notify: systemd daemon reload
 
+- name: Enable update-route53.service
+  ansible.builtin.systemd:
+    name: update-route53.service
+    enabled: yes
+
 - name: Start update-route53.service - ignore systemd dependency
   ansible.builtin.systemd:
     state: started


### PR DESCRIPTION
This needs to be run at boot-time to update DNS with the correct public IP address.